### PR TITLE
Fix file header line for package.el compatibility

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -1,4 +1,4 @@
-;;; alert --- Growl-style notification system for Emacs
+;;; alert.el --- Growl-style notification system for Emacs
 
 ;; Copyright (C) 2011-2013 John Wiegley
 


### PR DESCRIPTION
Just a quick fix so I can get this into MELPA. :-)

Emacs' built-in `auto-insert-mode` template for .el files includes the ".el" added here, so if you're using a different template, perhaps you can update it.

-Steve
