### PR TITLE
alert: add sender parameter to terminal-notifier

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -702,6 +702,7 @@ From https://github.com/alloy/terminal-notifier."
   (if alert-notifier-command
       (let ((args
              (list "-title"   (alert-encode-string (plist-get info :title))
+                   "-sender"  "org.gnu.Emacs"
                    "-message" (alert-encode-string (plist-get info :message)))))
         (apply #'call-process alert-notifier-command nil nil nil args))
     (alert-message-notify info)))


### PR DESCRIPTION
This allows the notifier to take correct action when the notification is clicked.
