### PR TITLE
Make alert styles in README/code comments consistent with types

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,15 +96,18 @@ chat on BitlBee:
 There are several builtin styles, and it is trivial to create new ones.
 The builtins are:
 
-| Name          | Summary                                                           |
-| ------------- | ------------------------------------------------------------------|
-| message       | Uses the Emacs `message` facility                                 |
-| log           | Logs the alert text to *Alerts*, with a timestamp                 |
-| ignore        | Ignores the alert entirely                                        |
-| fringe        | Changes the current frame's fringe background color               |
-| growl         | Uses Growl on OS X, if growlnotify is on the PATH                 |
-| gntp          | Uses gntp, it requires [gntp.el](https://github.com/tekai/gntp.el)|
-| notifications | Uses notifications library via D-Bus                              |
+| Name          | Summary                                                            |
+| ------------- | ------------------------------------------------------------------ |
+| fringe        | Changes the current frame's fringe background color                |
+| gntp          | Uses gntp, it requires [gntp.el](https://github.com/tekai/gntp.el) |
+| growl         | Uses Growl on OS X, if growlnotify is on the PATH                  |
+| ignore        | Ignores the alert entirely                                         |
+| libnotify     | Uses libnotify if notify-send is on the PATH                       |
+| log           | Logs the alert text to *Alerts*, with a timestamp                  |
+| message       | Uses the Emacs `message` facility                                  |
+| notifications | Uses notifications library via D-Bus                               |
+| notifier      | Uses terminal-notifier on OS X, if it is on the PATH               |
+| toaster       | Use the toast notification system                                  |
 
 # Defining new styles
 

--- a/alert.el
+++ b/alert.el
@@ -121,13 +121,16 @@
 ;; There are several builtin styles, and it is trivial to create new ones.
 ;; The builtins are:
 ;;
-;;   message   - Uses the Emacs `message' facility
-;;   log       - Logs the alert text to *Alerts*, with a timestamp
-;;   ignore    - Ignores the alert entirely
-;;   fringe    - Changes the current frame's fringe background color
-;;   growl     - Uses Growl on OS X, if growlnotify is on the PATH
-;;   libnotify - Uses libnotify if notify-send is on the PATH
-;;   notifier  - Uses terminal-notifier on OS X, if it is on the PATH
+;;   fringe        - Changes the current frame's fringe background color
+;;   gntp          - Uses gntp, it requires gntp.el (see https://github.com/tekai/gntp.el)
+;;   growl         - Uses Growl on OS X, if growlnotify is on the PATH
+;;   ignore        - Ignores the alert entirely
+;;   libnotify     - Uses libnotify if notify-send is on the PATH
+;;   log           - Logs the alert text to *Alerts*, with a timestamp
+;;   message       - Uses the Emacs `message' facility
+;;   notifications - Uses notifications library via D-Bus
+;;   notifier      - Uses terminal-notifier on OS X, if it is on the PATH
+;;   toaster       - Use the toast notification system
 ;;
 ;; * Defining new styles
 ;;


### PR DESCRIPTION
available in code. closes #18
