### PR TITLE
Use log4e to log the messages if it is available.

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -6,7 +6,7 @@
 ;; Created: 24 Aug 2011
 ;; Updated: 17 Feb 2013
 ;; Version: 1.1
-;; Package-Requires: ((gntp "0.1"))
+;; Package-Requires: ((gntp "0.1") (log4e "0.3.0"))
 ;; Keywords: notification emacs message
 ;; X-URL: https://github.com/jwiegley/alert
 
@@ -178,6 +178,7 @@
   (require 'cl))
 (require 'gntp nil t)
 (require 'notifications nil t)
+(require 'log4e nil t)
 
 (defgroup alert nil
   "Notification system for Emacs similar to Growl"
@@ -204,6 +205,23 @@
   "Colors associated by default with alert severities.
 This is used by styles external to Emacs that don't understand faces."
   :type '(alist :key-type symbol :value-type color)
+  :group 'alert)
+
+(defcustom alert-log-severity-functions
+  '((urgent   . alert--log-fatal)
+    (high     . alert--log-error)
+    (moderate . alert--log-warn)
+    (normal   . alert--log-info)
+    (low      . alert--log-debug)
+    (trivial  . alert--log-trace))
+  "Log4e logging functions"
+  :type '(alist :key-type symbol :value-type color)
+  :group 'alert)
+
+(defcustom alert-log-level
+  'normal
+  "Minimum level of messages to log"
+  :type 'symbol
   :group 'alert)
 
 (defcustom alert-reveal-idle-time 15
@@ -500,7 +518,23 @@ fringe gets colored whenever people chat on BitlBee:
 (defun alert-log-notify (info)
   (let* ((mes (plist-get info :message))
          (sev (plist-get info :severity))
-         (len (length mes)))
+         (len (length mes))
+         (func (cdr (assoc sev alert-severity-functions))))
+
+    ; when we get here you better be using log4e or have your logging
+    ; functions defined
+    (when (not (functionp func))
+      (log4e:deflogger "alert" "%t [%l] %m" "%H:%M:%S")
+      (when (functionp 'alert--log-set-level)
+        (alert--log-set-level alert-log-level)))
+
+    (when (not (functionp func))
+      (alert-legacy-log-notify mas sev len))
+;      (error "Log4e isn't being used and the logging functions aren't defined!"))
+
+    (apply func (list mes))))
+
+(defun alert-legacy-log-notify (mes sev len)
   (with-current-buffer
       (get-buffer-create "*Alerts*")
     (goto-char (point-max))
@@ -512,12 +546,15 @@ fringe gets colored whenever people chat on BitlBee:
     (insert ?\n))))
 
 (defun alert-log-clear (info)
-  (with-current-buffer
-      (get-buffer-create "*Alerts*")
-    (goto-char (point-max))
-    (insert (format-time-string "%H:%M %p - ")
-            "Clear: " (plist-get info :message)
-            ?\n)))
+  (if (functionp 'alert--log-clear-log)
+      (alert--log-clear-log)
+    (if (bufferp "*Alerts*")
+        (with-current-buffer
+            (get-buffer-create "*Alerts*")
+          (goto-char (point-max))
+          (insert (format-time-string "%H:%M %p - ")
+                  "Clear: " (plist-get info :message)
+                  ?\n)))))
 
 (alert-define-style 'log :title "Log to *Alerts* buffer"
                     :notifier #'alert-log-notify

--- a/alert.el
+++ b/alert.el
@@ -519,7 +519,7 @@ fringe gets colored whenever people chat on BitlBee:
   (let* ((mes (plist-get info :message))
          (sev (plist-get info :severity))
          (len (length mes))
-         (func (cdr (assoc sev alert-severity-functions))))
+         (func (cdr (assoc sev alert-log-severity-functions))))
 
     ; when we get here you better be using log4e or have your logging
     ; functions defined
@@ -529,7 +529,7 @@ fringe gets colored whenever people chat on BitlBee:
         (alert--log-set-level alert-log-level)))
 
     (when (not (functionp func))
-      (alert-legacy-log-notify mas sev len))
+      (alert-legacy-log-notify mes sev len))
 ;      (error "Log4e isn't being used and the logging functions aren't defined!"))
 
     (apply func (list mes))))
@@ -543,7 +543,7 @@ fringe gets colored whenever people chat on BitlBee:
     (set-text-properties (- (point) len) (point)
                        (list 'face (cdr (assq sev
                                               alert-severity-faces))))
-    (insert ?\n))))
+    (insert ?\n)))
 
 (defun alert-log-clear (info)
   (if (functionp 'alert--log-clear-log)

--- a/alert.el
+++ b/alert.el
@@ -251,6 +251,13 @@ The amount of idle time is governed by `alert-persist-idle-time'."
   :type 'boolean
   :group 'alert)
 
+(defcustom alert-default-icon
+  (concat data-directory
+          "images/icons/hicolor/scalable/apps/emacs.svg")
+  "Filename of default icon to show for libnotify-alerts."
+  :type 'string
+  :group 'alert)
+
 (defvar alert-styles nil)
 
 (defun alert-styles-radio-type (widget-name)
@@ -653,7 +660,8 @@ passed as a single symbol, a string or a list of symbols or
 strings."
   (if alert-libnotify-command
       (let* ((args
-              (list "--icon"     (or (plist-get info :icon) "Emacs")
+              (list "--icon"     (or (plist-get info :icon)
+                                     alert-default-icon)
                     "--app-name" "Emacs"
                     "--hint" "int:transient:1"
                     "--urgency"  (let ((urgency (cdr (assq


### PR DESCRIPTION
This allows reuse of library code instead of writing our own and
having to maintain it.