### PR TITLE
Fix libnotify error when category is of type string

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -675,7 +675,7 @@ strings."
                  (list "--category"
                        (cond ((symbolp category)
                               (symbol-name category))
-                             ((stringp category))
+                             ((stringp category) category)
                              ((listp category)
                               (mapconcat (if (symbolp (car category))
                                              #'symbol-name


### PR DESCRIPTION
Fixes #24 