### PR TITLE
OSX native notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The builtins are:
 | message       | Uses the Emacs `message` facility                                  |
 | notifications | Uses notifications library via D-Bus                               |
 | notifier      | Uses terminal-notifier on OS X, if it is on the PATH               |
+| osx-notifier  | Native OSX notification using AppleScript                          |
 | toaster       | Use the toast notification system                                  |
 
 # Defining new styles

--- a/alert.el
+++ b/alert.el
@@ -131,6 +131,7 @@
 ;;   message       - Uses the Emacs `message' facility
 ;;   notifications - Uses notifications library via D-Bus
 ;;   notifier      - Uses terminal-notifier on OS X, if it is on the PATH
+;;   osx-notifier  - Native OSX notifier using AppleScript
 ;;   toaster       - Use the toast notification system
 ;;
 ;; * Defining new styles

--- a/alert.el
+++ b/alert.el
@@ -778,11 +778,9 @@ From https://github.com/alloy/terminal-notifier."
                     :notifier #'alert-notifier-notify)
 
 (defun alert-osx-notifier-notify (info)
-  (let ((args
-	 (list "with title" (alert-encode-string (plist-get info :title))
-	       "with subtitle" (alert-encode-string (plist-get info :subtitle))
-	       "with sound" (alert-encode-string (plist-get info :sound)))))
-    (apply #'call-process "osascript -e 'display notifcation ....'"))
+  (apply #'call-process (format "osascript -e 'display notifcation %S with title %S'"
+				(alert-encode-string (plist-get info :message))
+				(alert-encode-string (plist-get info :title))))
   (alert-message-notify info))
 
 (alert-define-style 'osx-notifier :title "Notify using native OSX notification" :notifier #'alert-osx-notifier-notify)

--- a/alert.el
+++ b/alert.el
@@ -776,7 +776,17 @@ From https://github.com/alloy/terminal-notifier."
 
 (alert-define-style 'notifier :title "Notify using terminal-notifier"
                     :notifier #'alert-notifier-notify)
-
+
+(defun alert-osx-notifier-notify (info)
+  (let ((args
+	 (list "with title" (alert-encode-string (plist-get info :title))
+	       "with subtitle" (alert-encode-string (plist-get info :subtitle))
+	       "with sound" (alert-encode-string (plist-get info :sound)))))
+    (apply #'call-process "osascript -e 'display notifcation ....'"))
+  (alert-message-notify info))
+
+(alert-define-style 'osx-notifier :title "Notify using native OSX notification" :notifier #'alert-osx-notifier-notify)
+
 (defun alert-frame-notify (info)
   (let ((buf (plist-get info :buffer)))
     (if (eq (alert-buffer-status buf) 'buried)


### PR DESCRIPTION
Instead of relying on 3rd party programs this uses the native AppleScript method of displaying a notification.