### PR TITLE
Add 'Code:' meta comment

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -176,6 +176,8 @@
 ;;                        ;; the notifier function.
 ;;                        ))
 
+;;; Code:
+
 (eval-when-compile
   (require 'cl))
 (require 'gntp nil t)


### PR DESCRIPTION
Because 'M-x describe-package' shows not only comment part but also code part.

You can also see this issue at http://melpa.org/#/alert . `Description` block has contain code.