### PR TITLE
Avoid interpretation of `%' in message text as format specifier

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -569,7 +569,9 @@ fringe gets colored whenever people chat on BitlBee:
                     )
 
 (defun alert-message-notify (info)
-  (message (plist-get info :message))
+  ;; the message text might contain `%' and we don't want them to be
+  ;; interpreted as format specifiers:
+  (message "%s" (plist-get info :message))
   ;;(if (memq (plist-get info :severity) '(high urgency))
   ;;    (ding))
   )


### PR DESCRIPTION
When I was notified of a message containing an URL (http://redmine.example.com/projects/some_project/issues?utf8=%E2%9C%93), I got an error message instead:
`"Not enough arguments for format string"`

This patch avoids the problem.