### PR TITLE
Fix link in alert-notifier-command docstring

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -765,7 +765,7 @@ strings."
 
 (defcustom alert-notifier-command (executable-find "terminal-notifier")
   "Path to the terminal-notifier command.
-From https://github.com/alloy/terminal-notifier."
+From https://github.com/julienXX/terminal-notifier."
   :type 'file
   :group 'alert)
 


### PR DESCRIPTION
[alloy/terminal-notifier] now redirects to [julienXX/terminal-notifier]. This PR
corrects this link in the docstring for alert-notifier-command.

[alloy/terminal-notifier]: https://github.com/alloy/terminal-notifier
[julienXX/terminal-notifier]: https://github.com/julienXX/terminal-notifier