### PR TITLE
Add a new X11 notification style

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,32 +33,32 @@ For the user, there are several variables to control when and how alerts
 are presented.  By default, they appear in the minibuffer much the same
 as a normal Emacs message.  But there are many more possibilities:
 
-  - `alert-fade-time`  
+  - `alert-fade-time`
     Normally alerts disappear after this many seconds, if the style
     supports it.  The default is 5 seconds.
 
-  - `alert-default-style`  
+  - `alert-default-style`
     Pick the style to use if no other config rule matches.  The
     default is `message`, but `growl` works well too.
 
-  - `alert-reveal-idle-time`  
+  - `alert-reveal-idle-time`
     If a config rule choose to match on `idle`, this is how many
     seconds idle the user has to be.  Defaults to 5 so that users
     don't miss any alerts, but 120 is also good.
 
-  - `alert-persist-idle-time`  
+  - `alert-persist-idle-time`
     After this many idle seconds, alerts will become sticky, and not
     fade away more.  The default is 15 minutes.
 
-  - `alert-log-messages`  
+  - `alert-log-messages`
     By default, all alerts are logged to *Alerts* (and to *Messages*,
     if the `message` style is being used).  Set to nil to disable.
 
-  - `alert-hide-all-notifications`  
+  - `alert-hide-all-notifications`
     Want alerts off entirely?  They still get logged, however, unless
     you've turned that off too.
 
-  - `alert-user-configuration`  
+  - `alert-user-configuration`
     This variable lets you control exactly how and when a particular
     alert, a class of alerts, or all alerts, get reported -- or if at
     all.  Use this to make some alerts use Growl, while others are
@@ -110,6 +110,7 @@ The builtins are:
 | notifier      | Uses terminal-notifier on OS X, if it is on the PATH               |
 | osx-notifier  | Native OSX notification using AppleScript                          |
 | toaster       | Use the toast notification system                                  |
+| x11           | Changes the urgency property of the window in the X Window System
 
 # Defining new styles
 


### PR DESCRIPTION
This style changes the window property when using the X Window System
so that common window managers and desktop environments ( KDE, i3 )
show an automatic notification when using this alert style.