### PR TITLE
HOTFIX: Revert "Enable notifier style to fade out after `alert-fade-time`"

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -809,8 +809,7 @@ From https://github.com/julienXX/terminal-notifier."
       (let ((args
              (list "-title"   (alert-encode-string (plist-get info :title))
                    "-appIcon" (or (plist-get info :icon) alert-notifier-default-icon)
-                   "-message" (alert-encode-string (plist-get info :message))
-                   "-timeout" (number-to-string alert-fade-time))))
+                   "-message" (alert-encode-string (plist-get info :message)))))
         (apply #'call-process alert-notifier-command nil nil nil args))
     (alert-message-notify info)))
 


### PR DESCRIPTION
Reverts jwiegley/alert#56

This PR acts as a hotfix.

Sorry, man... I should have tested out more before I made the PR. I just realized that if you use the `-timeout` param, `terminal-notifier` runs synchronously and it blocks Emacs. I thought it was asynchronous based on the documentation which does not mention blocking at all... For example if you ran `terminal-notifier -timeout 5 -message "some message"` in a terminal, you will see that the terminal gets blocked for 5 seconds...

Maybe we can find a way to run the command asynchronously in Emacs later and still have it as a feature. I will have a look and submit another PR for that.