### PR TITLE
Fix: libnotify: properly pass expire-time args to notify-send

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -733,9 +733,14 @@ strings."
                                       "normal")))
                alert-libnotify-additional-args))
              (category (plist-get info :category)))
-        (if (and (plist-get info :persistent)
-                 (not (plist-get info :never-persist)))
-            (nconc args (list "--expire-time 0")))
+        (nconc args
+               (list "--expire-time"
+                     (number-to-string
+                      (* 1000 ; notify-send takes msecs
+                         (if (and (plist-get info :persistent)
+                                  (not (plist-get info :never-persist)))
+                             0 ; 0 indicates persistence
+                           alert-fade-time)))))
         (when category
           (nconc args
                  (list "--category"


### PR DESCRIPTION
'alert-fade-time' is multiplied by 1000 as notify-send uses msecs.
0 is the value passed when :persistent is 't'

fixes #28 

In case alert.el is included in Emacs:
My Emacs assignment/disclaimer process with the FSF was confirmed on 2009-10-29.