### PR TITLE
Use the built-in AppleScript support of Emacs MacPort

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -868,6 +868,14 @@ From https://github.com/julienXX/terminal-notifier."
                        (alert-encode-string (plist-get info :title)))))
   (alert-message-notify info))
 
+(when (fboundp 'mac-do-applescript)
+  ;; Use built-in AppleScript support when possible.
+  (defun alert-osx-notifier-notify (info)
+    (mac-do-applescript (format "display notification %S with title %S"
+                                (alert-encode-string (plist-get info :message))
+                                (alert-encode-string (plist-get info :title))))
+    (alert-message-notify info)))
+
 (alert-define-style 'osx-notifier :title "Notify using native OSX notification" :notifier #'alert-osx-notifier-notify)
 
 (defun alert-frame-notify (info)


### PR DESCRIPTION
[Emacs MacPort](https://bitbucket.org/mituharu/emacs-mac/overview) has AppleScript built-in, and the notifications get nice Emacs icons.

<img width="364" alt="image" src="https://user-images.githubusercontent.com/23358293/63200636-92bcbe00-c0b4-11e9-8b26-0f5ce991628e.png">
