### PR TITLE
change :foreground color for `alert-trivial-face`

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -406,7 +406,7 @@ For user customization, see `alert-user-configuration'.")
   :group 'alert)
 
 (defface alert-trivial-face
-  '((t (:foreground "Dark Purple")))
+  '((t (:foreground "Dark Violet")))
   "Trivial alert face."
   :group 'alert)
 


### PR DESCRIPTION
fix #63

Using `list-colors-display` one can confirm there is no "Dark Purple" color defined; however there is a "Dark Violet" so we'll use that.