### PR TITLE
Fix issue #92

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -1035,19 +1035,21 @@ MESSAGE is what the user will see.  You may also use keyword
 arguments to specify additional details.  Here is a full example:
 
 \(alert \"This is a message\"
-       :severity \\='high          ;; The default severity is `normal'
-       :title \"Title\"           ;; An optional title
-       :category \\='example       ;; A symbol to identify the message
-       :mode \\='text-mode         ;; Normally determined automatically
-       :buffer (current-buffer) ;; This is the default
-       :data nil                ;; Unused by alert.el itself
-       :persistent nil          ;; Force the alert to be persistent;
-                                ;; it is best not to use this
-       :never-persist nil       ;; Force this alert to never persist
-       :id \\='my-id)              ;; Used to replace previous message of
-                                ;; the same id in styles that support it
-       :style \\='fringe)          ;; Force a given style to be used;
-                                ;; this is only for debugging!
+       :severity \\='high            ;; The default severity is `normal'
+       :title \"Title\"              ;; An optional title
+       :category \\='example         ;; A symbol to identify the message
+       :mode \\='text-mode           ;; Normally determined automatically
+       :buffer (current-buffer)      ;; This is the default
+       :data nil                     ;; Unused by alert.el itself
+       :persistent nil               ;; Force the alert to be persistent;
+                                     ;; it is best not to use this
+       :never-persist nil            ;; Force this alert to never persist
+       :id \\='my-id)                ;; Used to replace previous message of
+                                     ;; the same id in styles that support it
+       :style \\='fringe)            ;; Force a given style to be used;
+                                     ;; this is only for debugging!
+       :icon \\=\"mail-message-new\" ;; if style supports icon then add icon
+                                     ;; name or path here
 
 If no :title is given, the buffer-name of :buffer is used.  If
 :buffer is nil, it is the current buffer at the point of call.
@@ -1091,7 +1093,8 @@ Here are some more typical examples of usage:
                            :buffer alert-buffer
                            :mode current-major-mode
                            :id id
-                           :data data))
+                           :data data
+                           :persistent persistent))
           matched)
 
       (if alert-log-messages
@@ -1099,8 +1102,9 @@ Here are some more typical examples of usage:
 
       (unless alert-hide-all-notifications
         (catch 'finish
-          (dolist (config (append alert-user-configuration
-                                  alert-internal-configuration))
+          (dolist (config (or (append alert-user-configuration
+                                      alert-internal-configuration)
+                              (when style '(nil))))
             (let* ((style-def (cdr (assq (or style (nth 1 config))
                                          alert-styles)))
                    (options (nth 2 config))


### PR DESCRIPTION
The `dolist` form in the `alert` function receives an empty list. This solution adds a single element `nil` to the list so that the `dolist` executes the body at least once.

Additionally, the `:persistent` keyword is added to the `base-info` variable, because when it is not in the base-info, then it will not get passed to the final `if` form (i.e. when the user has not configured some alert or added a `:style` keyword to the `alert` call).
Finally, the user can use the `:icon` keyword to set an icon, so that info is added to the `alert` docstring.

Currently, when using e.g. `libnotify` specifications for icons can be found in the Freedesktop [Icon Naming Specification](https://specifications.freedesktop.org/icon-naming-spec/icon-naming-spec-latest.html).