### PR TITLE
Pass through user defined :persistent value

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -1089,6 +1089,7 @@ Here are some more typical examples of usage:
                            :severity severity
                            :category category
                            :buffer alert-buffer
+			   :persistent persistent
                            :mode current-major-mode
                            :id id
                            :data data))

--- a/alert.el
+++ b/alert.el
@@ -1089,7 +1089,7 @@ Here are some more typical examples of usage:
                            :severity severity
                            :category category
                            :buffer alert-buffer
-			   :persistent persistent
+                           :persistent persistent
                            :mode current-major-mode
                            :id id
                            :data data))


### PR DESCRIPTION
All values allowed to be defined should get passed through in `:info` otherwise it's confusing to users why options aren't applying.