### PR TITLE
Use cl-case instead of case

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -676,7 +676,7 @@ This is found in the Growl Extras: http://growl.info/extras.php."
                         (cdr (assq (plist-get info :severity)
                                    alert-growl-priorities))))
              (args
-              (case system-type
+              (cl-case system-type
                 ('windows-nt (mapcar
                               (lambda (lst) (apply #'concat lst))
                               `(
@@ -691,11 +691,11 @@ This is found in the Growl Extras: http://growl.info/extras.php."
                     "--priority" priority)))))
         (if (and (plist-get info :persistent)
                  (not (plist-get info :never-persist)))
-            (case system-type
+            (cl-case system-type
               ('windows-nt (nconc args (list "/s:true")))
               (t (nconc args (list "--sticky")))))
         (let ((message (alert-encode-string (plist-get info :message))))
-          (case system-type
+          (cl-case system-type
             ('windows-nt (nconc args (list message)))
             (t (nconc args (list "--message" message)))))
         (apply #'call-process alert-growl-command nil nil nil args))


### PR DESCRIPTION
Since 'case' is an obsolete alias (as of 27.1); use ‘cl-case’ instead.