### PR TITLE
Use do-applescript instead of mac-do-applescript

### DIFF
--- a/alert.el
+++ b/alert.el
@@ -884,12 +884,12 @@ From https://github.com/julienXX/terminal-notifier."
                        (alert-encode-string (plist-get info :title)))))
   (alert-message-notify info))
 
-(when (fboundp 'mac-do-applescript)
+(when (fboundp 'do-applescript)
   ;; Use built-in AppleScript support when possible.
   (defun alert-osx-notifier-notify (info)
-    (mac-do-applescript (format "display notification %S with title %S"
-                                (alert-encode-string (plist-get info :message))
-                                (alert-encode-string (plist-get info :title))))
+    (do-applescript (format "display notification %S with title %S"
+                            (alert-encode-string (plist-get info :message))
+                            (alert-encode-string (plist-get info :title))))
     (alert-message-notify info)))
 
 (alert-define-style 'osx-notifier :title "Notify using native OSX notification" :notifier #'alert-osx-notifier-notify)


### PR DESCRIPTION
do-applescript is an alias for ns-do-applescript in Emacs NS port (Official GNU Emacs repository) and mac-do-applescript in Emacs Carbon/Mac port (https://bitbucket.org/mituharu/emacs-mac/src/master/).

Enable native macOS notification in both NS port and Carbon port.